### PR TITLE
Fix nested tensor warning for transformer

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -1,6 +1,6 @@
 import argparse
 import torch
-from model import TransformerLM, generate_square_subsequent_mask
+from .model import TransformerLM, generate_square_subsequent_mask
 
 
 def load_model(model_path, d_model, nhead, num_layers, dim_ff, dropout, device):

--- a/src/model.py
+++ b/src/model.py
@@ -9,16 +9,22 @@ class TransformerLM(nn.Module):
         self.d_model = d_model
         self.embedding = nn.Embedding(vocab_size, d_model)
         self.pos_encoder = PositionalEncoding(d_model, dropout)
-        encoder_layer = nn.TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model,
+            nhead,
+            dim_feedforward,
+            dropout,
+            batch_first=True,
+        )
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers)
         self.fc_out = nn.Linear(d_model, vocab_size)
 
     def forward(self, src, src_mask=None):
         src = self.embedding(src) * math.sqrt(self.d_model)
         src = self.pos_encoder(src)
-        output = self.transformer(src.transpose(0,1), mask=src_mask)
+        output = self.transformer(src, mask=src_mask)
         output = self.fc_out(output)
-        return output.transpose(0,1)
+        return output
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, dropout=0.1, max_len=5000):

--- a/src/train.py
+++ b/src/train.py
@@ -3,8 +3,8 @@ import math
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from data import build_dataloader
-from model import TransformerLM, generate_square_subsequent_mask
+from .data import build_dataloader
+from .model import TransformerLM, generate_square_subsequent_mask
 import tqdm
 
 def evaluate(model, data_loader, criterion, device):


### PR DESCRIPTION
## Summary
- use `batch_first=True` in Transformer encoder
- adjust forward accordingly
- switch to relative imports for training and generation modules

## Testing
- `python - <<'PY'
import torch
from src.model import TransformerLM, generate_square_subsequent_mask
model = TransformerLM(100, d_model=64, nhead=4, num_layers=1)
x = torch.randint(0,100,(2,10))
mask = generate_square_subsequent_mask(10)
out = model(x, mask)
print(out.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68562d1c8e70832cab337f637ba57703