### PR TITLE
Fix dataset to respect sentence boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project provides a small transformer-based causal language model
 implemented with PyTorch. The corpus should be a plain text file where
 tokens are separated by spaces and sentences by new lines.
+During preprocessing each line is treated independently so training
+samples never cross sentence boundaries.
 
 ## Requirements
 

--- a/src/data.py
+++ b/src/data.py
@@ -5,9 +5,10 @@ from collections import Counter
 class TextDataset(Dataset):
     def __init__(self, path, seq_len=32, min_freq=1):
         with open(path, 'r', encoding='utf-8') as f:
-            text = f.read()
-        tokens = text.split()
-        counter = Counter(tokens)
+            sentences = [line.strip() for line in f if line.strip()]
+
+        token_lists = [s.split() for s in sentences]
+        counter = Counter(tok for toks in token_lists for tok in toks)
         self.vocab = {
             token: i + 2
             for i, (token, freq) in enumerate(counter.items())
@@ -16,11 +17,12 @@ class TextDataset(Dataset):
         self.vocab['<pad>'] = 0
         self.vocab['<unk>'] = 1
         self.inv_vocab = {i: t for t, i in self.vocab.items()}
-        ids = [self.vocab.get(tok, 1) for tok in tokens]
         self.seq_len = seq_len
         self.data = []
-        for i in range(0, len(ids) - seq_len):
-            self.data.append((ids[i:i+seq_len], ids[i+1:i+seq_len+1]))
+        for tokens in token_lists:
+            ids = [self.vocab.get(tok, 1) for tok in tokens]
+            for i in range(0, len(ids) - seq_len):
+                self.data.append((ids[i:i+seq_len], ids[i+1:i+seq_len+1]))
 
     def __len__(self):
         return len(self.data)

--- a/src/generate.py
+++ b/src/generate.py
@@ -1,6 +1,6 @@
 import argparse
 import torch
-from model import TransformerLM, generate_square_subsequent_mask
+from .model import TransformerLM, generate_square_subsequent_mask
 
 
 def load_model(model_path, d_model, nhead, num_layers, dim_ff, dropout, device):

--- a/src/model.py
+++ b/src/model.py
@@ -9,16 +9,22 @@ class TransformerLM(nn.Module):
         self.d_model = d_model
         self.embedding = nn.Embedding(vocab_size, d_model)
         self.pos_encoder = PositionalEncoding(d_model, dropout)
-        encoder_layer = nn.TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model,
+            nhead,
+            dim_feedforward,
+            dropout,
+            batch_first=True,
+        )
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers)
         self.fc_out = nn.Linear(d_model, vocab_size)
 
     def forward(self, src, src_mask=None):
         src = self.embedding(src) * math.sqrt(self.d_model)
         src = self.pos_encoder(src)
-        output = self.transformer(src.transpose(0,1), mask=src_mask)
+        output = self.transformer(src, mask=src_mask)
         output = self.fc_out(output)
-        return output.transpose(0,1)
+        return output
 
 class PositionalEncoding(nn.Module):
     def __init__(self, d_model, dropout=0.1, max_len=5000):

--- a/src/train.py
+++ b/src/train.py
@@ -3,8 +3,8 @@ import math
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from data import build_dataloader
-from model import TransformerLM, generate_square_subsequent_mask
+from .data import build_dataloader
+from .model import TransformerLM, generate_square_subsequent_mask
 import tqdm
 
 def evaluate(model, data_loader, criterion, device):


### PR DESCRIPTION
## Summary
- handle text line by line when building the dataset
- document sentence-level preprocessing in README

## Testing
- `python - <<'PY'
from src.data import build_dataloader
with open('temp.txt','w') as f:
    f.write('hello world\nthis is a test')
_, loader = build_dataloader('temp.txt', seq_len=2, batch_size=1)
for src, tgt in loader:
    print(src, tgt)
PY`
- `python -m src.train --corpus temp.txt --seq-len 2 --batch-size 2 --epochs 1 --d-model 32 --nhead 4 --num-layers 1 --dim-ff 64 --output out.pt`
- `python -m src.generate --model out.pt --prompt hello --length 2 --d-model 32 --nhead 4 --num-layers 1 --dim-ff 64`


------
https://chatgpt.com/codex/tasks/task_e_68562d1c8e70832cab337f637ba57703