### PR TITLE
Add seq2seq transformer training and evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,23 @@ python -m src.generate --model model.pt --prompt "The" --length 20
 
 The architecture parameters should match those used during training and
 default to the same values as in `src.train`.
+
+## Sequence-to-Sequence Transformer
+
+The `src/seq2seq` package contains a small transformer model for tasks with
+parallel text files. Each line in the source file corresponds to a line in the
+target file. Training can be started with
+
+```bash
+python -m src.seq2seq.train --src path/to/train.src --tgt path/to/train.tgt \
+    --epochs 10 --batch-size 32
+```
+
+A trained model can be evaluated on a test set using
+
+```bash
+python -m src.seq2seq.evaluate --model seq2seq_model.pt \
+    --src path/to/test.src --tgt path/to/test.tgt
+```
+
+The evaluation script reports token accuracy based on greedy decoding.

--- a/src/seq2seq/data.py
+++ b/src/seq2seq/data.py
@@ -1,0 +1,53 @@
+import torch
+from torch.utils.data import Dataset, DataLoader
+from collections import Counter
+
+class ParallelTextDataset(Dataset):
+    """Dataset for parallel text files."""
+    def __init__(self, src_path, tgt_path, min_freq=1):
+        with open(src_path, 'r', encoding='utf-8') as f:
+            src_lines = [l.strip() for l in f if l.strip()]
+        with open(tgt_path, 'r', encoding='utf-8') as f:
+            tgt_lines = [l.strip() for l in f if l.strip()]
+        assert len(src_lines) == len(tgt_lines), "Source and target files must have same number of lines"
+
+        self.src_tokens = [l.split() for l in src_lines]
+        self.tgt_tokens = [l.split() for l in tgt_lines]
+
+        src_counter = Counter(tok for sent in self.src_tokens for tok in sent)
+        tgt_counter = Counter(tok for sent in self.tgt_tokens for tok in sent)
+
+        self.src_vocab = {'<pad>':0, '<unk>':1}
+        for tok, freq in src_counter.items():
+            if freq >= min_freq:
+                self.src_vocab.setdefault(tok, len(self.src_vocab))
+
+        self.tgt_vocab = {'<pad>':0, '<unk>':1, '<bos>':2, '<eos>':3}
+        for tok, freq in tgt_counter.items():
+            if freq >= min_freq:
+                self.tgt_vocab.setdefault(tok, len(self.tgt_vocab))
+
+        self.data = []
+        for s_tokens, t_tokens in zip(self.src_tokens, self.tgt_tokens):
+            src_ids = [self.src_vocab.get(tok, 1) for tok in s_tokens]
+            tgt_ids = [2] + [self.tgt_vocab.get(tok, 1) for tok in t_tokens] + [3]
+            self.data.append((src_ids, tgt_ids))
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+def collate_fn(batch):
+    src_batch, tgt_batch = zip(*batch)
+    src_len = max(len(s) for s in src_batch)
+    tgt_len = max(len(t) for t in tgt_batch)
+    padded_src = [s + [0]*(src_len - len(s)) for s in src_batch]
+    padded_tgt = [t + [0]*(tgt_len - len(t)) for t in tgt_batch]
+    return torch.tensor(padded_src), torch.tensor(padded_tgt)
+
+def build_dataloader(src_path, tgt_path, batch_size=32, min_freq=1, shuffle=True):
+    dataset = ParallelTextDataset(src_path, tgt_path, min_freq)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, collate_fn=collate_fn)
+    return dataset, loader

--- a/src/seq2seq/evaluate.py
+++ b/src/seq2seq/evaluate.py
@@ -1,0 +1,78 @@
+import argparse
+import torch
+from .model import Seq2SeqTransformer
+from .data import build_dataloader, collate_fn
+from ..model import generate_square_subsequent_mask
+
+
+def load_model(path, device, d_model, nhead, num_layers, dim_ff, dropout):
+    checkpoint = torch.load(path, map_location=device)
+    model = Seq2SeqTransformer(
+        len(checkpoint['src_vocab']),
+        len(checkpoint['tgt_vocab']),
+        d_model, nhead, num_layers, dim_ff, dropout
+    ).to(device)
+    model.load_state_dict(checkpoint['model_state_dict'])
+    model.eval()
+    return model, checkpoint['src_vocab'], checkpoint['tgt_vocab']
+
+
+def greedy_decode(model, src, src_vocab, tgt_vocab, device, max_len=50):
+    src = torch.tensor([src], device=device)
+    src_mask = None
+    memory = model.encode(src, src_mask, src == 0)
+    ys = torch.tensor([[tgt_vocab['<bos>']]], device=device)
+    for _ in range(max_len):
+        tgt_mask = generate_square_subsequent_mask(ys.size(1)).to(device)
+        out = model.decode(ys, memory, tgt_mask=tgt_mask,
+                           memory_padding_mask=src == 0,
+                           tgt_padding_mask=ys == 0)
+        prob = model.fc_out(out[:, -1])
+        next_word = prob.argmax(dim=-1).item()
+        ys = torch.cat([ys, torch.tensor([[next_word]], device=device)], dim=1)
+        if next_word == tgt_vocab['<eos>']:
+            break
+    return ys.squeeze(0).tolist()[1:]
+
+
+def compute_accuracy(model, dataset, device):
+    correct = 0
+    total = 0
+    for src_ids, tgt_ids in dataset.data:
+        pred = greedy_decode(model, src_ids, dataset.src_vocab, dataset.tgt_vocab, device, max_len=len(tgt_ids)+2)
+        # remove eos if present
+        if pred and pred[-1] == dataset.tgt_vocab['<eos>']:
+            pred = pred[:-1]
+        target = tgt_ids[1:]  # skip bos
+        length = min(len(pred), len(target))
+        for p, t in zip(pred[:length], target[:length]):
+            if p == t:
+                correct += 1
+        total += len(target)
+    return correct / total if total > 0 else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Evaluate seq2seq model')
+    parser.add_argument('--model', required=True, help='Path to trained model')
+    parser.add_argument('--src', required=True, help='Path to test source file')
+    parser.add_argument('--tgt', required=True, help='Path to test target file')
+    parser.add_argument('--d-model', type=int, default=128)
+    parser.add_argument('--nhead', type=int, default=4)
+    parser.add_argument('--num-layers', type=int, default=2)
+    parser.add_argument('--dim-ff', type=int, default=512)
+    parser.add_argument('--dropout', type=float, default=0.1)
+    args = parser.parse_args()
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model, src_vocab, tgt_vocab = load_model(
+        args.model, device, args.d_model, args.nhead, args.num_layers, args.dim_ff, args.dropout
+    )
+    dataset, _ = build_dataloader(args.src, args.tgt, batch_size=1, shuffle=False, min_freq=1)
+    dataset.src_vocab = src_vocab
+    dataset.tgt_vocab = tgt_vocab
+    acc = compute_accuracy(model, dataset, device)
+    print(f'Accuracy: {acc*100:.2f}%')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/seq2seq/model.py
+++ b/src/seq2seq/model.py
@@ -1,0 +1,53 @@
+import math
+import torch
+import torch.nn as nn
+from ..model import PositionalEncoding, generate_square_subsequent_mask
+
+class Seq2SeqTransformer(nn.Module):
+    def __init__(self, src_vocab_size, tgt_vocab_size,
+                 d_model=128, nhead=4, num_layers=2,
+                 dim_feedforward=512, dropout=0.1):
+        super().__init__()
+        self.d_model = d_model
+        self.src_emb = nn.Embedding(src_vocab_size, d_model)
+        self.tgt_emb = nn.Embedding(tgt_vocab_size, d_model)
+        self.pos_enc = PositionalEncoding(d_model, dropout)
+        self.transformer = nn.Transformer(
+            d_model=d_model,
+            nhead=nhead,
+            num_encoder_layers=num_layers,
+            num_decoder_layers=num_layers,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.fc_out = nn.Linear(d_model, tgt_vocab_size)
+
+    def forward(self, src, tgt, src_mask=None, tgt_mask=None,
+                src_padding_mask=None, tgt_padding_mask=None):
+        src = self.pos_enc(self.src_emb(src) * math.sqrt(self.d_model))
+        tgt = self.pos_enc(self.tgt_emb(tgt) * math.sqrt(self.d_model))
+        memory = self.transformer.encoder(src, mask=src_mask,
+                                          src_key_padding_mask=src_padding_mask)
+        out = self.transformer.decoder(
+            tgt, memory,
+            tgt_mask=tgt_mask,
+            memory_key_padding_mask=src_padding_mask,
+            tgt_key_padding_mask=tgt_padding_mask,
+        )
+        return self.fc_out(out)
+
+    def encode(self, src, src_mask=None, src_padding_mask=None):
+        src = self.pos_enc(self.src_emb(src) * math.sqrt(self.d_model))
+        return self.transformer.encoder(src, mask=src_mask,
+                                        src_key_padding_mask=src_padding_mask)
+
+    def decode(self, tgt, memory, tgt_mask=None, tgt_padding_mask=None,
+               memory_padding_mask=None):
+        tgt = self.pos_enc(self.tgt_emb(tgt) * math.sqrt(self.d_model))
+        return self.transformer.decoder(
+            tgt, memory,
+            tgt_mask=tgt_mask,
+            memory_key_padding_mask=memory_padding_mask,
+            tgt_key_padding_mask=tgt_padding_mask,
+        )

--- a/src/seq2seq/train.py
+++ b/src/seq2seq/train.py
@@ -1,0 +1,96 @@
+import argparse
+import math
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from .data import build_dataloader
+from .model import Seq2SeqTransformer
+from ..model import generate_square_subsequent_mask
+import tqdm
+
+def evaluate(model, loader, criterion, device):
+    model.eval()
+    total_loss = 0.0
+    with torch.no_grad():
+        for src, tgt in loader:
+            src = src.to(device)
+            tgt = tgt.to(device)
+            tgt_inp = tgt[:, :-1]
+            tgt_out = tgt[:, 1:]
+            tgt_mask = generate_square_subsequent_mask(tgt_inp.size(1)).to(device)
+            src_pad_mask = src == 0
+            tgt_pad_mask = tgt_inp == 0
+            out = model(src, tgt_inp, tgt_mask=tgt_mask,
+                        src_padding_mask=src_pad_mask,
+                        tgt_padding_mask=tgt_pad_mask)
+            loss = criterion(out.reshape(-1, out.size(-1)), tgt_out.reshape(-1))
+            total_loss += loss.item() * src.size(0)
+    return total_loss / len(loader.dataset)
+
+def train(args):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    dataset, train_loader = build_dataloader(
+        args.src, args.tgt, args.batch_size, args.min_freq)
+    val_loader = None
+    if args.eval_src and args.eval_tgt:
+        _, val_loader = build_dataloader(
+            args.eval_src, args.eval_tgt, args.batch_size, args.min_freq)
+    model = Seq2SeqTransformer(
+        len(dataset.src_vocab), len(dataset.tgt_vocab),
+        args.d_model, args.nhead, args.num_layers,
+        args.dim_ff, args.dropout
+    ).to(device)
+    criterion = nn.CrossEntropyLoss(ignore_index=dataset.tgt_vocab['<pad>'])
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        total_loss = 0.0
+        for src, tgt in tqdm.tqdm(train_loader):
+            src = src.to(device)
+            tgt = tgt.to(device)
+            tgt_inp = tgt[:, :-1]
+            tgt_out = tgt[:, 1:]
+            tgt_mask = generate_square_subsequent_mask(tgt_inp.size(1)).to(device)
+            src_pad_mask = src == 0
+            tgt_pad_mask = tgt_inp == 0
+            optimizer.zero_grad()
+            out = model(src, tgt_inp, tgt_mask=tgt_mask,
+                        src_padding_mask=src_pad_mask,
+                        tgt_padding_mask=tgt_pad_mask)
+            loss = criterion(out.reshape(-1, out.size(-1)), tgt_out.reshape(-1))
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * src.size(0)
+        avg_loss = total_loss / len(train_loader.dataset)
+        ppl = math.exp(avg_loss)
+        print(f"Epoch {epoch}: loss={avg_loss:.4f} ppl={ppl:.4f}")
+        if val_loader:
+            val_loss = evaluate(model, val_loader, criterion, device)
+            val_ppl = math.exp(val_loss)
+            print(f"  Val : loss={val_loss:.4f} ppl={val_ppl:.4f}")
+    torch.save({'model_state_dict': model.state_dict(),
+                'src_vocab': dataset.src_vocab,
+                'tgt_vocab': dataset.tgt_vocab}, args.output)
+    print('Training completed. Model saved to', args.output)
+
+def main():
+    parser = argparse.ArgumentParser(description='Train seq2seq Transformer')
+    parser.add_argument('--src', required=True, help='Path to source text file')
+    parser.add_argument('--tgt', required=True, help='Path to target text file')
+    parser.add_argument('--eval-src', type=str, default=None)
+    parser.add_argument('--eval-tgt', type=str, default=None)
+    parser.add_argument('--batch-size', type=int, default=32)
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--lr', type=float, default=1e-3)
+    parser.add_argument('--min-freq', type=int, default=1)
+    parser.add_argument('--d-model', type=int, default=128)
+    parser.add_argument('--nhead', type=int, default=4)
+    parser.add_argument('--num-layers', type=int, default=2)
+    parser.add_argument('--dim-ff', type=int, default=512)
+    parser.add_argument('--dropout', type=float, default=0.1)
+    parser.add_argument('--output', type=str, default='seq2seq_model.pt')
+    args = parser.parse_args()
+    train(args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `src/seq2seq` package for sequence-to-sequence training
- implement dataset loader using parallel text files
- build a seq2seq Transformer model
- provide training and evaluation scripts
- document usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685658ec8d54832c99acce682f8db3c2