### PR TITLE
Fix seq2seq training data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ target file. Training can be started with
 python -m src.seq2seq.train --src path/to/train.src --tgt path/to/train.tgt \
     --epochs 10 --batch-size 32
 ```
+The training dataloader shuffles the data to encourage better optimisation.
 
 A trained model can be evaluated on a test set using
 

--- a/src/seq2seq/data.py
+++ b/src/seq2seq/data.py
@@ -7,10 +7,12 @@ class ParallelTextDataset(Dataset):
     def __init__(self, src_path, tgt_path, min_freq=1):
         self.src_path = src_path
         self.tgt_path = tgt_path
-        
-        self.run(src_path, tgt_path, min_freq=1)
+
+        # honour the minimum frequency parameter when building vocabularies
+        self.run(src_path, tgt_path, min_freq)
         
     def run(self, src_path, tgt_path, min_freq=1):
+        """Load data and build vocabularies."""
         with open(src_path, 'r', encoding='utf-8') as f:
             src_lines = [l.strip() for l in f if l.strip()]
         with open(tgt_path, 'r', encoding='utf-8') as f:

--- a/src/seq2seq/train.py
+++ b/src/seq2seq/train.py
@@ -30,7 +30,7 @@ def evaluate(model, loader, criterion, device):
 def train(args):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     dataset, train_loader = build_dataloader(
-        args.src, args.tgt, args.batch_size, args.min_freq)
+        args.src, args.tgt, args.batch_size, args.min_freq, shuffle=True)
     val_loader = None
     if args.eval_src and args.eval_tgt:
         _, val_loader = build_dataloader(


### PR DESCRIPTION
## Summary
- honour `min_freq` argument when building vocabularies
- shuffle training data in seq2seq trainer
- document that the dataloader is shuffled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856670f1c40832caa2c71223151784b