### PR TITLE
Fix seq2seq training data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ target file. Training can be started with
 python -m src.seq2seq.train --src path/to/train.src --tgt path/to/train.tgt \
     --epochs 10 --batch-size 32
 ```
+The training dataloader shuffles the data to encourage better optimisation.
+Before training starts the script prints how many `<unk>` tokens appear in the
+dataset so you can verify your vocabularies cover most tokens.
 
 A trained model can be evaluated on a test set using
 

--- a/src/model.py
+++ b/src/model.py
@@ -39,11 +39,12 @@ class PositionalEncoding(nn.Module):
         self.register_buffer('pe', pe)
 
     def forward(self, x):
+        # x shape: (batch, seq_len, d_model) when batch_first=True
         x = x + self.pe[:, :x.size(1)]
         return self.dropout(x)
 
 
 def generate_square_subsequent_mask(sz):
-    mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
-    mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
+    """Return an upper-triangular matrix of -inf, 0.0 for masking future tokens."""
+    mask = torch.triu(torch.full((sz, sz), float('-inf')), diagonal=1)
     return mask

--- a/src/seq2seq/train.py
+++ b/src/seq2seq/train.py
@@ -30,7 +30,11 @@ def evaluate(model, loader, criterion, device):
 def train(args):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     dataset, train_loader = build_dataloader(
-        args.src, args.tgt, args.batch_size, args.min_freq)
+        args.src, args.tgt, args.batch_size, args.min_freq, shuffle=True)
+    if dataset.src_unk_count or dataset.tgt_unk_count:
+        print(f"<unk> tokens - src: {dataset.src_unk_count}, tgt: {dataset.tgt_unk_count}")
+    else:
+        print("No <unk> tokens in training data")
     val_loader = None
     if args.eval_src and args.eval_tgt:
         _, val_loader = build_dataloader(


### PR DESCRIPTION
## Summary
- honour `min_freq` argument when building vocabularies
- shuffle training data in seq2seq trainer
- document that the dataloader is shuffled
- report `<unk>` token counts before training
- clarify positional encoding usage and simplify mask implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856670f1c40832caa2c71223151784b